### PR TITLE
fix: dont make sink async

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const getIterator = require('get-iterator')
 module.exports = function pair () {
   let _source, onSource
 
-  const sink = async source => {
+  const sink = source => {
     if (_source) throw new Error('already piped')
     _source = getIterator(source)
     if (onSource) onSource(_source)

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,6 @@ tape('simple - error', async function (t) {
   try {
     await pipe(p.source, collect)
   } catch (_err) {
-    console.log(_err)
     t.equal(_err, err)
     t.end()
   }


### PR DESCRIPTION
The sink function was marked as async even though it took no async
action. As it also throws an error this can create problems
downstream if the caller is not catching the async error. While
consumers should account for the error, since this is not an async
function it unncessarily complicates error handling as intermediate
libraries that could do things synchronously and bubble the error up,
now need to handle everything async.